### PR TITLE
Higher priority

### DIFF
--- a/src/ZfrCors/Mvc/CorsRequestListener.php
+++ b/src/ZfrCors/Mvc/CorsRequestListener.php
@@ -52,7 +52,7 @@ class CorsRequestListener extends AbstractListenerAggregate
      */
     public function attach(EventManagerInterface $events)
     {
-        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'onCorsRequest'), -10);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_ROUTE, array($this, 'onCorsRequest'), -1);
     }
 
     /**


### PR DESCRIPTION
As we want this to be done as soon as we have the route match (as said on IRC, as it is today we could do it before resolving the route match, but in the case we update this module to allow filtering by route, let's still do that after).

I have augmented the priority so that no negative listeners are executed before this one.
