### PR TITLE
Send Access-Control-Allow-Credentials in response to simple requests as well

### DIFF
--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -147,8 +147,7 @@ class CorsService
                 $headers->addHeaderLine('Vary', 'Origin');
             }
         }
-		
-		if ($this->options->getAllowedCredentials()) {
+        if ($this->options->getAllowedCredentials()) {
             $headers->addHeaderLine('Access-Control-Allow-Credentials', 'true');
         }
 

--- a/tests/ZfrCorsTest/Service/CorsServiceTest.php
+++ b/tests/ZfrCorsTest/Service/CorsServiceTest.php
@@ -231,8 +231,8 @@ class CorsServiceTest extends TestCase
         $this->assertTrue($headers->has('Vary'));
         $this->assertEquals('Foo, Origin', $headers->get('Vary')->getFieldValue());
     }
-	
-	public function testPopulatesAllowCredentialsNormalCorsRequest()
+
+    public function testPopulatesAllowCredentialsNormalCorsRequest()
     {
         $request  = new HttpRequest();
         $response = new HttpResponse();


### PR DESCRIPTION
Should fix issue 2 and allow the example scenario as posted by Mozilla on https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS?redirectlocale=en-US&redirectslug=HTTP_access_control#Requests_with_credentials
