### PR TITLE
Added Vary-Header when there's no Origin.

### DIFF
--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -167,10 +167,14 @@ class CorsService
             return '*';
         }
 
-        $origin = $request->getHeader('Origin')->getFieldValue();
-        foreach ($allowedOrigins as $allowedOrigin) {
-            if (fnmatch($allowedOrigin, $origin)) {
-                return $origin;
+        $origin = $request->getHeader('Origin');
+
+        if ($origin) {
+            $origin = $origin->getFieldValue();
+            foreach ($allowedOrigins as $allowedOrigin) {
+                if (fnmatch($allowedOrigin, $origin)) {
+                    return $origin;
+                }
             }
         }
 

--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -128,10 +128,12 @@ class CorsService
         // a simple request, it is useless to continue the processing as it will be refused
         // by the browser anyway, so we throw an exception
         if ($origin === 'null') {
+            $origin = $request->getHeader('Origin');
+            $originHeader = $origin ? $origin->getFieldValue() : '';
             throw new DisallowedOriginException(
                 sprintf(
                     'The origin "%s" is not authorized',
-                    $request->getHeader('Origin')->getFieldValue()
+                    $originHeader
                 )
             );
         }

--- a/tests/ZfrCorsTest/Service/CorsServiceTest.php
+++ b/tests/ZfrCorsTest/Service/CorsServiceTest.php
@@ -236,6 +236,19 @@ class CorsServiceTest extends TestCase
         $this->assertEquals('null', $headers->get('Access-Control-Allow-Origin')->getFieldValue());
     }
 
+    public function testEnsureVaryHeaderForNoOrigin()
+    {
+        $request  = new HttpRequest();
+        $response = new HttpResponse();
+
+        $this->corsService->populateCorsResponse($request, $response);
+
+        $headers = $request->getHeaders();
+
+        $this->assertEquals(false, $headers->get('Origin'));
+        $this->assertNotEquals(false, $headers->get('Vary'));
+    }
+
     public function testCanPopulateNormalCorsRequest()
     {
         $request  = new HttpRequest();


### PR DESCRIPTION
Ensure that the vary header is set when no origin is set to prevent reverse proxy caching a wrong request; causing all of the following requests to fail due to missing CORS headers.