### PR TITLE
Ensure that the vary header is set when no origin is set 

### DIFF
--- a/src/ZfrCors/Mvc/CorsRequestListener.php
+++ b/src/ZfrCors/Mvc/CorsRequestListener.php
@@ -121,7 +121,7 @@ class CorsRequestListener extends AbstractListenerAggregate
         // to prevent reverse proxy caching a wrong request; causing all of the following
         // requests to fail due to missing CORS headers.
         if (!$this->corsService->isCorsRequest($request)) {
-            if (!$request->getHeader("Origin")) {
+            if (!$request->getHeader('Origin')) {
                 $this->corsService->ensureVaryHeader($response);
             }
             return;

--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -142,11 +142,13 @@ class CorsService
         $headers->addHeaderLine('Access-Control-Allow-Origin', $origin);
         $headers->addHeaderLine('Access-Control-Expose-Headers', implode(', ', $this->options->getExposedHeaders()));
 
-        $this->ensureVaryHeader($response);
+        $headers = $this->ensureVaryHeader($response);
 
         if ($this->options->getAllowedCredentials()) {
             $headers->addHeaderLine('Access-Control-Allow-Credentials', 'true');
         }
+
+        $response->setHeaders($headers);
 
         return $response;
     }
@@ -189,6 +191,7 @@ class CorsService
      *
      * @link http://www.w3.org/TR/cors/#resource-implementation
      * @param HttpResponse $response
+     * @return \Zend\Http\Headers
      */
     public function ensureVaryHeader(HttpResponse $response)
     {
@@ -198,7 +201,7 @@ class CorsService
         $allowedOrigins = $this->options->getAllowedOrigins();
 
         if (in_array('*', $allowedOrigins)) {
-            return;
+            return $headers;
         }
         if ($headers->has('Vary')) {
             $varyHeader = $headers->get('Vary');
@@ -209,5 +212,7 @@ class CorsService
         } else {
             $headers->addHeaderLine('Vary', 'Origin');
         }
+
+        return $headers;
     }
 }

--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -167,10 +167,14 @@ class CorsService
             return '*';
         }
 
-        $origin = $request->getHeader('Origin')->getFieldValue();
-        foreach ($allowedOrigins as $allowedOrigin) {
-            if (fnmatch($allowedOrigin, $origin)) {
-                return $origin;
+        $origin = $request->getHeader('Origin');
+
+        if ($origin) {
+            $origin = $origin->getFieldValue();
+            foreach ($allowedOrigins as $allowedOrigin) {
+                if (fnmatch($allowedOrigin, $origin)) {
+                    return $origin;
+                }
             }
         }
 

--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -128,10 +128,12 @@ class CorsService
         // a simple request, it is useless to continue the processing as it will be refused
         // by the browser anyway, so we throw an exception
         if ($origin === 'null') {
+            $origin = $request->getHeader('Origin');
+            $originHeader = $origin ? $origin->getFieldValue() : '';
             throw new DisallowedOriginException(
                 sprintf(
                     'The origin "%s" is not authorized',
-                    $request->getHeader('Origin')->getFieldValue()
+                    $originHeader
                 )
             );
         }

--- a/tests/ZfrCorsTest/Service/CorsServiceTest.php
+++ b/tests/ZfrCorsTest/Service/CorsServiceTest.php
@@ -236,6 +236,19 @@ class CorsServiceTest extends TestCase
         $this->assertEquals('null', $headers->get('Access-Control-Allow-Origin')->getFieldValue());
     }
 
+    public function testEnsureVaryHeaderForNoOrigin()
+    {
+        $request  = new HttpRequest();
+        $response = new HttpResponse();
+
+        $this->corsService->populateCorsResponse($request, $response);
+
+        $headers = $request->getHeaders();
+
+        $this->assertEquals(false, $headers->get('Origin'));
+        $this->assertNotEquals(false, $headers->get('Vary'));
+    }
+
     public function testCanPopulateNormalCorsRequest()
     {
         $request  = new HttpRequest();

--- a/tests/ZfrCorsTest/Service/CorsServiceTest.php
+++ b/tests/ZfrCorsTest/Service/CorsServiceTest.php
@@ -241,9 +241,13 @@ class CorsServiceTest extends TestCase
         $request  = new HttpRequest();
         $response = new HttpResponse();
 
-        $this->corsService->populateCorsResponse($request, $response);
+        if (!$this->corsService->isCorsRequest($request)) {
+            if (!$request->getHeader("Origin")) {
+                $this->corsService->ensureVaryHeader($response);
+            }
+        }
 
-        $headers = $request->getHeaders();
+        $headers = $response->getHeaders();
 
         $this->assertEquals(false, $headers->get('Origin'));
         $this->assertNotEquals(false, $headers->get('Vary'));

--- a/tests/ZfrCorsTest/Service/CorsServiceTest.php
+++ b/tests/ZfrCorsTest/Service/CorsServiceTest.php
@@ -238,14 +238,9 @@ class CorsServiceTest extends TestCase
 
     public function testEnsureVaryHeaderForNoOrigin()
     {
-        $request  = new HttpRequest();
         $response = new HttpResponse();
 
-        if (!$this->corsService->isCorsRequest($request)) {
-            if (!$request->getHeader("Origin")) {
-                $this->corsService->ensureVaryHeader($response);
-            }
-        }
+        $this->corsService->ensureVaryHeader($response);
 
         $headers = $response->getHeaders();
 


### PR DESCRIPTION
Ensure that the vary header is set when no origin is set to prevent reverse proxy caching a wrong request; causing all of the following requests to fail due to missing CORS headers.