### PR TITLE
Resolved wildcard usage + credentials flag issue

### DIFF
--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -167,14 +167,13 @@ class CorsService
     {
         $allowedOrigins = $this->options->getAllowedOrigins();
 
-        if (in_array('*', $allowedOrigins)) {
-            return '*';
-        }
-
         $origin = $request->getHeader('Origin');
 
         if ($origin) {
             $origin = $origin->getFieldValue();
+            if (in_array('*', $allowedOrigins)) {
+                return $origin;
+            }
             foreach ($allowedOrigins as $allowedOrigin) {
                 if (fnmatch($allowedOrigin, $origin)) {
                     return $origin;


### PR DESCRIPTION
A wildcard '*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true.
