### PR TITLE
send 204 response on pre-flight request

### DIFF
--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -95,7 +95,7 @@ class CorsService
     public function createPreflightCorsResponse(HttpRequest $request)
     {
         $response = new HttpResponse();
-        $response->setStatusCode(200);
+        $response->setStatusCode(204);
 
         $headers = $response->getHeaders();
 
@@ -103,7 +103,6 @@ class CorsService
         $headers->addHeaderLine('Access-Control-Allow-Methods', implode(', ', $this->options->getAllowedMethods()));
         $headers->addHeaderLine('Access-Control-Allow-Headers', implode(', ', $this->options->getAllowedHeaders()));
         $headers->addHeaderLine('Access-Control-Max-Age', $this->options->getMaxAge());
-        $headers->addHeaderLine('Content-Length', 0);
 
         if ($this->options->getAllowedCredentials()) {
             $headers->addHeaderLine('Access-Control-Allow-Credentials', 'true');


### PR DESCRIPTION
This is sending a `204 No Content` response instead of `200 OK` + `Content-Length: 0` to reduce traffic and to avoid nginx from compressing an empty body which happens if the gzip module is enabled as the pre-flight request will be send very often.

I tested it with FF and Chrome and it works fine.
But I'm unsure about it after reading http://stackoverflow.com/questions/14702962/can-an-http-options-request-return-a-204-or-should-it-always-return-200 which confuses me a lot.