### PR TITLE
Expose module to zend-component-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
             "homepage": "http://www.michaelgallego.fr/"
         }
     ],
+    "extra": {
+        "zf": {
+            "module": "ZfrCors"
+        }
+    },
     "require": {
         "php": "^5.6 || ^7.0",
         "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "68af1fcb78c1aaaccd2ee3bb6421893f",
-    "content-hash": "56383fd572811e663239073c077926fd",
+    "hash": "39efbda0b11292e9cece7e4428e37411",
+    "content-hash": "0c7df4d70ec7aafc4f61583f488162b7",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -2970,8 +2970,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
-    "prefer-stable": true,
-    "prefer-lowest": true,
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": "^5.6 || ^7.0"
     },


### PR DESCRIPTION
This adds configuration to allow [zend-component-installer](https://github.com/zendframework/zend-component-installer) to detect that this is a module, and then attempt to add it to the ZF application on successful installation via Composer.