### PR TITLE
Preflight CORS response should return 204 status code 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ As of now, all the various options are set globally for all routes:
 ### Preflight request
 
 If ZfrCors detects a preflight CORS request, a new HTTP response will be created, and ZfrCors will send the appropriate
-headers according to your configuration. The response will be always sent with a 200 status code (OK).
+headers according to your configuration. The response will be always sent with a 204 status code (No Content).
 
 Please note that this will also prevent further MVC steps from being executed, since all subsequent MVC steps are
 skipped till `Zend\Mvc\MvcEvent::EVENT_FINISH`, which is responsible for actually sending the response.

--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -95,7 +95,7 @@ class CorsService
     public function createPreflightCorsResponse(HttpRequest $request)
     {
         $response = new HttpResponse();
-        $response->setStatusCode(200);
+        $response->setStatusCode(204);
 
         $headers = $response->getHeaders();
 

--- a/tests/ZfrCorsTest/Service/CorsServiceTest.php
+++ b/tests/ZfrCorsTest/Service/CorsServiceTest.php
@@ -125,7 +125,7 @@ class CorsServiceTest extends TestCase
 
         $headers = $response->getHeaders();
 
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(204, $response->getStatusCode());
         $this->assertEquals('', $response->getContent());
         $this->assertEquals('http://example.com', $headers->get('Access-Control-Allow-Origin')->getFieldValue());
         $this->assertEquals(


### PR DESCRIPTION
This would prevent nginx from logging `zero size buf in output`