### PR TITLE
[Bugfix] Unhandled exception in `CorsRequestListener`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,16 @@ matrix:
     - php: 7
       env:
         - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - DEPS=locked
+        - CS_CHECK=true
+    - php: 7.1
+      env:
+        - DEPS=latest
     - php: hhvm
       env:
         - DEPS=lowest

--- a/src/ZfrCors/Mvc/CorsRequestListener.php
+++ b/src/ZfrCors/Mvc/CorsRequestListener.php
@@ -134,7 +134,7 @@ class CorsRequestListener extends AbstractListenerAggregate
             // InvalidOriginException should already be handled by `CorsRequestListener::onCorsPreflight`
             return;
         }
-        
+
         // Also ensure that the vary header is set when no origin is set
         // to prevent reverse proxy caching a wrong request; causing all of the following
         // requests to fail due to missing CORS headers.

--- a/src/ZfrCors/Mvc/CorsRequestListener.php
+++ b/src/ZfrCors/Mvc/CorsRequestListener.php
@@ -128,10 +128,17 @@ class CorsRequestListener extends AbstractListenerAggregate
             return;
         }
 
+        try {
+            $isCorsRequest = $this->corsService->isCorsRequest($request);
+        } catch (InvalidOriginException $exception) {
+            // InvalidOriginException should already be handled by `CorsRequestListener::onCorsPreflight`
+            return;
+        }
+        
         // Also ensure that the vary header is set when no origin is set
         // to prevent reverse proxy caching a wrong request; causing all of the following
         // requests to fail due to missing CORS headers.
-        if (! $this->corsService->isCorsRequest($request)) {
+        if (! $isCorsRequest) {
             if (! $request->getHeader('Origin')) {
                 $this->corsService->ensureVaryHeader($response);
             }

--- a/tests/ZfrCorsTest/Mvc/CorsRequestListenerTest.php
+++ b/tests/ZfrCorsTest/Mvc/CorsRequestListenerTest.php
@@ -156,4 +156,25 @@ class CorsRequestListenerTest extends TestCase
         $this->assertEquals(400, $response->getStatusCode());
         $this->assertEquals('', $response->getContent());
     }
+    
+    /**
+     * Application always triggers `MvcEvent::EVENT_FINISH` and since the `CorsRequestListener` is listening on it, we
+     * should handle the exception aswell.
+     *
+     *
+     * @return void
+     */
+    public function testOnCorsRequestCanHandleInvalidOriginHeaderValue()
+    {
+        $mvcEvent = new MvcEvent();
+        $request  = new HttpRequest();
+        $response = new HttpResponse();
+    
+        $request->getHeaders()->addHeaderLine('Origin', 'file:');
+    
+        $mvcEvent->setRequest($request)
+            ->setResponse($response);
+    
+        $this->corsListener->onCorsRequest($mvcEvent);
+    }
 }

--- a/tests/ZfrCorsTest/Mvc/CorsRequestListenerTest.php
+++ b/tests/ZfrCorsTest/Mvc/CorsRequestListenerTest.php
@@ -156,7 +156,7 @@ class CorsRequestListenerTest extends TestCase
         $this->assertEquals(400, $response->getStatusCode());
         $this->assertEquals('', $response->getContent());
     }
-    
+
     /**
      * Application always triggers `MvcEvent::EVENT_FINISH` and since the `CorsRequestListener` is listening on it, we
      * should handle the exception aswell.
@@ -169,12 +169,12 @@ class CorsRequestListenerTest extends TestCase
         $mvcEvent = new MvcEvent();
         $request  = new HttpRequest();
         $response = new HttpResponse();
-    
+
         $request->getHeaders()->addHeaderLine('Origin', 'file:');
-    
+
         $mvcEvent->setRequest($request)
             ->setResponse($response);
-    
+
         $this->corsListener->onCorsRequest($mvcEvent);
     }
 }


### PR DESCRIPTION
Since ZF always triggers `MvcEvent::EVENT_FINISH`, the `CorsRequestListener::onCorsRequest` method is called even if the `Origin`-Header is invalid. 
Since we did not catch the exception in that method, an unhandled exception was thrown through the application.