### PR TITLE
Do not crash application if custom scheme is not registered

### DIFF
--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -22,6 +22,7 @@ use Zend\Mvc\Router\Http\RouteMatch as DeprecatedRouteMatch;
 use Zend\Router\Http\RouteMatch;
 use Zend\Http\Header;
 use Zend\Uri\UriFactory;
+use Zend\Uri\Exception\InvalidArgumentException as UriInvalidException;
 use ZfrCors\Exception\DisallowedOriginException;
 use ZfrCors\Exception\InvalidOriginException;
 use ZfrCors\Options\CorsOptions;
@@ -69,6 +70,8 @@ class CorsService
         try {
             $origin = $headers->get('Origin');
         } catch (Header\Exception\InvalidArgumentException $exception) {
+            throw InvalidOriginException::fromInvalidHeaderValue();
+        } catch (UriInvalidException $exception) {
             throw InvalidOriginException::fromInvalidHeaderValue();
         }
 


### PR DESCRIPTION
If custom url scheme such as "chrome-extension" is not registered, request with header "Origin: chrome-extension://..." will crush application:

PHP Fatal error:  Uncaught Zend\Uri\Exception\InvalidArgumentException: no class registered for scheme "chrome-extension" in /vendor/zendframework/zend-uri/src/UriFactory.php:104
 Stack trace:
 #0 /vendor/zendframework/zend-http/src/Header/Origin.php(32): Zend\Uri\UriFactory::factory('chrome-extensio...')
 #1 /vendor/zendframework/zend-http/src/Headers.php(446): Zend\Http\Header\Origin::fromString('Origin: chrome-...')
 #2 /vendor/zendframework/zend-http/src/Headers.php(285): Zend\Http\Headers->lazyLoadHeader(4)
 #3 /vendor/zfr/zfr-cors/src/ZfrCors/Service/CorsService.php(70): Zend\Http\Headers->get('Origin')
 #4 /vendor/zfr/zfr-cors/src/ZfrCors/Mvc/CorsRequestListener.php(89): ZfrCors\Service\CorsService->isCorsRequest(Object(ZF\ContentNegotiation\Request))

It happens because nobody catch InvalidArgumentException from UriFactory in Zend\Http\Header\Origin::fromString.

Requests with "Origin: chrome-extension://..." or "Origin: moz-extension://..." sometimes occur on my production site. This requests are sent from my site users, that is why I can't just register several custom url schemes in my onBootstrap().

I think it would be better to response with 400 code (as described in CorsRequestListener->onCorsPreflight), than to crush application with 500 error.