### PR TITLE
Fixed issue with `zendframework/zend-http` v2.8

### DIFF
--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -72,7 +72,7 @@ class CorsService
             throw InvalidOriginException::fromInvalidHeaderValue();
         }
 
-        if (!$origin instanceof Header\Origin) {
+        if (! $origin instanceof Header\Origin) {
             throw InvalidOriginException::fromInvalidHeaderValue();
         }
 

--- a/src/ZfrCors/Service/CorsService.php
+++ b/src/ZfrCors/Service/CorsService.php
@@ -72,6 +72,10 @@ class CorsService
             throw InvalidOriginException::fromInvalidHeaderValue();
         }
 
+        if (!$origin instanceof Header\Origin) {
+            throw InvalidOriginException::fromInvalidHeaderValue();
+        }
+
         $originUri  = UriFactory::factory($origin->getFieldValue());
         $requestUri = $request->getUri();
 


### PR DESCRIPTION
In `zendframework/zend-http` v2.8 they introduced generic fallback to `GenericHeader` instead of throwing `Zend\Http\Header\Exception\InvalidArgumentException`